### PR TITLE
Add default values support to DwcaWriter

### DIFF
--- a/src/main/java/org/gbif/dwc/text/DwcaWriter.java
+++ b/src/main/java/org/gbif/dwc/text/DwcaWriter.java
@@ -411,8 +411,9 @@ public class DwcaWriter {
     // check if default values are provided for this rowType
     Map<Term,String> termDefaultValueMap = defaultValues.get(rowType);
     if(termDefaultValueMap != null){
-      ArchiveField field = new ArchiveField();
+      ArchiveField field = null;
       for (Term t : termDefaultValueMap.keySet()) {
+        field = new ArchiveField();
         field.setTerm(t);
         field.setDefaultValue(termDefaultValueMap.get(t));
         af.addField(field);

--- a/src/test/java/org/gbif/dwc/text/DwcaWriterTest.java
+++ b/src/test/java/org/gbif/dwc/text/DwcaWriterTest.java
@@ -318,6 +318,7 @@ public class DwcaWriterTest {
     writer.addCoreColumn(DwcTerm.acceptedNameUsageID, null);
     
     writer.addCoreDefaultValue(DwcTerm.collectionCode, "A2Z");
+    writer.addCoreDefaultValue(DwcTerm.countryCode, "CA");
     writer.close();
 
     Archive arch = ArchiveFactory.openArchive(dwcaDir);
@@ -327,5 +328,6 @@ public class DwcaWriterTest {
     assertEquals("dummy1", firstRecord.value(DwcTerm.taxonID));
     assertEquals("A2Z", firstRecord.value(DwcTerm.collectionCode));
     assertEquals("A2Z", arch.getCore().getField(DwcTerm.collectionCode).getDefaultValue());
+    assertEquals("CA", arch.getCore().getField(DwcTerm.countryCode).getDefaultValue());
   }
 }


### PR DESCRIPTION
Ready for review.
The implementation allows to set default values before, during or after calling `addCoreColumn(...)` and `addExtensionRecord(...)`.

The cost of that is a check on all `addCoreColumn(...)` and `addExtensionRecord(...)` calls to ensure we do not overwrite a default value. An alternative might be to throw an `IllegalStateException` on the `close()` if we have a value **and** a default value for the same rowType/term.

What do you think?
