### PR TITLE
Issue #20 : Change StarRecordImpl.hasExtension to return false if no records attached

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ target/
 *.jar
 *.war
 *.ear
+
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif</groupId>
     <artifactId>motherpom</artifactId>
-    <version>37</version>
+    <version>38-SNAPSHOT</version>
   </parent>
 
   <artifactId>dwca-io</artifactId>

--- a/src/main/java/org/gbif/dwca/record/StarRecordImpl.java
+++ b/src/main/java/org/gbif/dwca/record/StarRecordImpl.java
@@ -37,7 +37,7 @@ public class StarRecordImpl implements StarRecord {
   }
 
   public boolean hasExtension(Term rowType) {
-    return extensions.containsKey(rowType);
+    return extensions.containsKey(rowType) && !extensions.get(rowType).isEmpty();
   }
 
   /**


### PR DESCRIPTION
This fixes #20 by changing the behaviour of hasExtension to return false if there are no records attached, even if the rowType exists as a key.

Practically, there should be little change in cases where code was not already broken. Any iterations over the extension would have been done over an empty list in the past, so this should just short-circuit that behaviour and make the control flow flow the way it would be expected to flow if a rowType had no records currently attached to it. Calls to StarRecordImpl.extension(Term) will still return empty List's in those cases, but the use of hasExtension as a guard for those calls is now simpler (previously could have used List.isEmpty(), but the List may not have existed anyway.

In my case, I was having issues with the use of newCoreRecord in Archive.next(), which was returning StarRecord objects that had hasExtension returning true, but extension(Term) returning an empty List, which was not expected and not in the shortlist of places to look for a bug at first. The behaviour should now be to return false for hasExtension in those cases.