### PR TITLE
Fix #29 : Add default values from Darwin Core Text to ArchiveFile

### DIFF
--- a/src/main/java/org/gbif/dwca/io/ArchiveFile.java
+++ b/src/main/java/org/gbif/dwca/io/ArchiveFile.java
@@ -67,8 +67,8 @@ public class ArchiveFile implements Iterable<Record> {
   private Archive archive;
   private final LinkedList<String> locations = new LinkedList<String>();
   private String title;
-  private String fieldsTerminatedBy;
-  private Character fieldsEnclosedBy;
+  private String fieldsTerminatedBy = ",";
+  private Character fieldsEnclosedBy = '"';
   // this is actually ignored by the CSVReader and any of \n, \r or \n\r is used
   private String linesTerminatedBy = "\n";
   private String encoding = "utf8";


### PR DESCRIPTION
Adds missing default values from Darwin Core Text Guide to ArchiveFile:

http://rs.tdwg.org/dwc/terms/guides/text/

I did not add a default rowType, as it has "required" in the guide so its default value is a little ambiguous because of that.