### PR TITLE
Fix #32 : Shade and upgrade Guava

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 .classpath
 .project
 .settings/
+
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,17 @@
     <jdkLevel>1.8</jdkLevel>
 
     <commons-io.version>2.5</commons-io.version>
-    <commons-lang.version>3.4</commons-lang.version>
+    <commons-lang.version>3.6</commons-lang.version>
     <commons-digester.version>3.2</commons-digester.version>
     <dwc-api.version>1.17</dwc-api.version>
     <freemarker.version>2.3.25-incubating</freemarker.version>
     <gbif-common.version>0.35</gbif-common.version>
     <gbif-registry-metadata.version>2.59</gbif-registry-metadata.version>
-    <guava.version>18.0</guava.version>
+    <guava.version>23.0</guava.version>
     <junit.version>4.12</junit.version>
-    <logback.version>1.1.7</logback.version>
-    <mockito.version>2.8.9</mockito.version>
-    <slf4j.version>1.7.21</slf4j.version>
+    <logback.version>1.2.3</logback.version>
+    <mockito.version>2.8.47</mockito.version>
+    <slf4j.version>1.7.25</slf4j.version>
   </properties>
 
   <repositories>
@@ -55,10 +55,31 @@
   <build>
     <defaultGoal>install</defaultGoal>
     <plugins>
-      <!--
-          to build jar with all dependencies:
-          mvn assembly:single
-      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>com.google.guava:guava</include>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>org.gbif.dwcaio.shaded.com.google.common</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/src/main/java/org/gbif/dwca/record/RecordIterator.java
+++ b/src/main/java/org/gbif/dwca/record/RecordIterator.java
@@ -24,6 +24,7 @@ import org.gbif.utils.file.ClosableIterator;
 import org.gbif.utils.file.csv.CSVReader;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -58,7 +59,7 @@ public class RecordIterator implements ClosableIterator<Record> {
     this.replaceEntities = replaceEntities;
     closable = recordSource;
     if (closable == null) {
-      Iterator<String[]> empty = Iterators.emptyIterator();
+      Iterator<String[]> empty = Collections.emptyIterator();
       iter = Iterators.peekingIterator(empty);
     } else {
       iter = Iterators.peekingIterator(closable);


### PR DESCRIPTION
Guava regularly bumps its major version and includes method removals in the process of doing so, which fits with Semantic Versioning, but which limits reuse of libraries that externally depend on it. This removes that obstacle by shading/removing Guava as an external dependency, so it can be upgraded locally without affecting others.

Also updates Apache Commons libraries (do not need shading as they have a much longer maintenance cycle), and Slf4J (Does not need shading as it has a very reputable history in terms of backwards compatibility). Logback is only used as a test dependency, so bumping to keep up with latest bug fixes, but no effect on downstream projects.

Fixes one removed method since Guava-18.0 by replacing it with a standard Java Collections API method.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>